### PR TITLE
Use githack since RawGit shutdown

### DIFF
--- a/smartapps/tonesto7/st-community-installer.src/st-community-installer.groovy
+++ b/smartapps/tonesto7/st-community-installer.src/st-community-installer.groovy
@@ -157,7 +157,7 @@ def getAccessToken() {
 }
 
 def gitBranch()         { return "master" }
-def getAppImg(file)	    { return "https://cdn.rawgit.com/tonesto7/st-community-installer/${gitBranch()}/images/$file" }
-def getAppVideo(file)	{ return "https://cdn.rawgit.com/tonesto7/st-community-installer/${gitBranch()}/videos/$file" }
+def getAppImg(file)	    { return "https://raw.githack.com/tonesto7/st-community-installer/${gitBranch()}/images/$file" }
+def getAppVideo(file)	{ return "https://raw.githack.com/tonesto7/st-community-installer/${gitBranch()}/videos/$file" }
 def getAppEndpointUrl(subPath)	{ return "${apiServerUrl("/api/smartapps/installations/${app.id}${subPath ? "/${subPath}" : ""}?access_token=${atomicState.accessToken}")}" }
 


### PR DESCRIPTION
> RawGit is now in a sunset phase and will soon shut down. It's been a fun five years, but all things must end. GitHub repositories that served content through RawGit within the last month will continue to be served until at least October of 2019. URLs for other repositories are no longer being served. If you're currently using RawGit, please stop using it as soon as you can.

As a side note, `getAppVideo(file)` points to a videos folder but I don't see one in the repository.